### PR TITLE
fix: properly replace all periods in the memoization key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class ICU {
 
   parse(res, options, lng, ns, key, info) {
     const hadSuccessfulLookup = info && info.resolved && info.resolved.res;
-    const memKey = this.options.memoize && `${lng}.${ns}.${key.replace('.', '###')}`;
+    const memKey = this.options.memoize && `${lng}.${ns}.${key.replace(/\./g, '###')}`;
 
     let fc;
     if (this.options.memoize) {


### PR DESCRIPTION
The correct fix for #6, this time replacing all periods, not just the first one.