### PR TITLE
security: guard the memoize setPath/pushPath walker against prototype pollution

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,9 @@
+// Keys that must never be traversed when walking a string/array path into an
+// object, otherwise a crafted path such as `__proto__.polluted` walks straight
+// into Object.prototype. Mirrors the guard shipped to the same setPath/pushPath
+// walker in i18next-fs-backend 2.6.6 and i18next-http-middleware 3.9.7.
+const UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype'];
+
 function getLastOfPath(object, path, Empty) {
   function cleanKey(key) {
     return (key && key.indexOf('###') > -1) ? key.replace(/###/g, '.') : key;
@@ -12,25 +18,27 @@ function getLastOfPath(object, path, Empty) {
     if (canNotTraverseDeeper()) return {};
 
     const key = cleanKey(stack.shift());
+    if (UNSAFE_KEYS.indexOf(key) > -1) return {};
     if (!object[key] && Empty) object[key] = new Empty();
     object = object[key];
   }
 
   if (canNotTraverseDeeper()) return {};
-  return {
-    obj: object,
-    k: cleanKey(stack.shift())
-  };
+  const k = cleanKey(stack.shift());
+  if (UNSAFE_KEYS.indexOf(k) > -1) return {};
+  return { obj: object, k };
 }
 
 export function setPath(object, path, newValue) {
   const { obj, k } = getLastOfPath(object, path, Object);
+  if (obj === undefined) return; // unsafe path, drop silently
 
   obj[k] = newValue;
 }
 
 export function pushPath(object, path, newValue, concat) {
   const { obj, k } = getLastOfPath(object, path, Object);
+  if (obj === undefined) return; // unsafe path, drop silently
 
   obj[k] = obj[k] || [];
   if (concat) obj[k] = obj[k].concat(newValue);

--- a/test/security.spec.js
+++ b/test/security.spec.js
@@ -1,0 +1,97 @@
+import areIntlLocalesSupported from "intl-locales-supported";
+
+const isARSupported = areIntlLocalesSupported(['en', 'ar-AR']) && Intl.NumberFormat('ar-AR').format(1000) === '١٬٠٠٠';
+
+if (global.Intl) {
+  if (!isARSupported) {
+    const polyFill = require("intl");
+    Intl.NumberFormat = polyFill.NumberFormat;
+    Intl.DateTimeFormat = polyFill.DateTimeFormat;
+  }
+} else {
+  global.Intl = require("intl");
+}
+
+import ICU from "../src/";
+import { setPath, pushPath, getPath } from "../src/utils.js";
+
+describe("prototype pollution guards", () => {
+  afterEach(() => {
+    // make sure no test leaks pollution into the rest of the suite
+    delete Object.prototype.polluted;
+    delete Object.prototype.greeting;
+  });
+
+  describe("setPath / pushPath / getPath walker", () => {
+    it("setPath drops a write whose path traverses __proto__", () => {
+      const store = {};
+      setPath(store, "__proto__.polluted", "PWNED");
+      expect(({}).polluted).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(store).toEqual({});
+    });
+
+    it("setPath drops a write whose intermediate segment is constructor / prototype", () => {
+      const store = {};
+      setPath(store, "en.constructor.prototype.polluted", "PWNED");
+      setPath(store, "en.__proto__.greeting", "PWNED");
+      expect(({}).polluted).toBeUndefined();
+      expect(({}).greeting).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(Object.prototype.greeting).toBeUndefined();
+    });
+
+    it("setPath drops a write whose final segment is an unsafe key", () => {
+      const store = {};
+      setPath(store, "en.translation.__proto__", { isAdmin: true });
+      expect(({}).isAdmin).toBeUndefined();
+      expect(Object.prototype.isAdmin).toBeUndefined();
+    });
+
+    it("setPath still writes legitimate nested paths", () => {
+      const store = {};
+      setPath(store, "en.translation.greeting", "hello");
+      expect(store.en.translation.greeting).toBe("hello");
+    });
+
+    it("pushPath drops a write whose path traverses an unsafe key", () => {
+      const store = {};
+      pushPath(store, "__proto__.polluted", "PWNED");
+      expect(({}).polluted).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(store).toEqual({});
+    });
+
+    it("getPath does not traverse unsafe keys", () => {
+      Object.prototype.polluted = "PWNED";
+      try {
+        expect(getPath({}, "__proto__.polluted")).toBeUndefined();
+      } finally {
+        delete Object.prototype.polluted;
+      }
+    });
+  });
+
+  describe("parse() memoize cache", () => {
+    // The memoize cache key is `${lng}.${ns}.${key}` (only the trailing key is
+    // ###-escaped; lng and ns are not), and it is written into an in-memory
+    // object via the same setPath walker. A prototype-name namespace segment
+    // therefore reaches the walker. Same reachable segment as the namespace
+    // case in the i18next-fs-backend / i18next-http-middleware advisories.
+    it("does not pollute Object.prototype when the namespace is a prototype name", () => {
+      const icu = new ICU();
+      icu.init(null, {});
+      const out = icu.parse("hello world", {}, "en", "__proto__", "greeting");
+      expect(out).toBe("hello world");
+      expect(({}).greeting).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty("greeting")).toBe(false);
+    });
+
+    it("still memoizes legitimate namespaces", () => {
+      const icu = new ICU();
+      icu.init(null, {});
+      icu.parse("hello {name}", { name: "Tom" }, "en", "translation", "greeting");
+      expect(getPath(icu.mem, "en.translation.greeting")).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
`src/utils.js` carries a copy of i18next's `getLastOfPath` / `setPath` / `pushPath` walker, and `parse()` uses it to populate the memoize cache:

```js
const memKey = this.options.memoize && `${lng}.${ns}.${key.replace(/\./g, '###')}`;
...
if (this.options.memoize && (...)) utils.setPath(this.mem, memKey, fc);
```

Only the trailing `key` is escaped (dots to `###`). `lng` and `ns` go into the path verbatim, so a namespace named `__proto__`, `constructor` or `prototype` makes the walker descend into `Object.prototype`. With the default `memoize: true`, `parse('hello', {}, 'en', '__proto__', 'greeting')` ends up running `Object.prototype.greeting = <IntlMessageFormat>`.

That is the same walker, and the same gap, that was closed in two sibling packages during the May 2026 coordinated disclosure (both credited to @codeswhite):

- i18next-fs-backend 2.6.6, commit 3ab0448, "security: guard setPath/pushPath traversal against prototype pollution" (GHSA-2933-q333-qg83)
- i18next-http-middleware 3.9.7, commit 7c6d26f, "security: reject missing keys whose split segments hit __proto__ / constructor / prototype" (GHSA-f49m-vf83-692w)

This brings i18next-icu to parity by adding the same `UNSAFE_KEYS` guard to `getLastOfPath` (intermediate segments and the final key) and dropping the write when a path is refused. Legitimate dotted and nested keys are unaffected.

In practice the namespace is the reachable segment: a prototype name passed as `lng` is rejected earlier by IntlMessageFormat's locale check, and the formatter only runs on a resource that actually resolves. So this is defence in depth in the same spirit as the http-middleware fix rather than a new critical path, but it keeps the shared walker consistent across the family.

Verification (Node, full suite):

- Added `test/security.spec.js`. With the guard reverted, the new setPath/pushPath/getPath cases and the end to end `parse()` case go red (the parse case shows `Object.prototype.greeting` becoming the cached formatter). With the guard in place all 23 tests pass.
- Both ways: unsafe paths are dropped, while legitimate nested writes and normal memoization still work.
